### PR TITLE
Use OpenFreeMap style in comparison examples

### DIFF
--- a/example/austin.html
+++ b/example/austin.html
@@ -34,14 +34,14 @@
       const austin = [-97.7431, 30.2672];
       const beforeMap = new maplibregl.Map({
         container: 'before',
-        style: 'https://demotiles.maplibre.org/style.json',
+        style: 'https://tiles.openfreemap.org/styles/liberty',
         center: austin,
         zoom: 12
       });
 
       const afterMap = new maplibregl.Map({
         container: 'after',
-        style: 'https://demotiles.maplibre.org/style.json',
+        style: 'https://tiles.openfreemap.org/styles/liberty',
         center: austin,
         zoom: 12
       });

--- a/example/index.js
+++ b/example/index.js
@@ -2,17 +2,16 @@
 
 require("../");
 
-// 'Before' style from https://github.com/lukasmartinelli/naturalearthtiles
+// Both sides use the same OpenFreeMap style
 var before = new maplibregl.Map({
   container: "before",
-  style: "https://raw.githubusercontent.com/lukasmartinelli/naturalearthtiles/gh-pages/maps/natural_earth.vector.json",
+  style: "https://tiles.openfreemap.org/styles/liberty",
   zoom: 2
 });
 
-// 'After' style from https://github.com/maplibre/demotiles
 var after = new maplibregl.Map({
   container: "after",
-  style: "https://demotiles.maplibre.org/style.json",
+  style: "https://tiles.openfreemap.org/styles/liberty",
   zoom: 2
 });
 


### PR DESCRIPTION
## Summary
- Show OpenFreeMap's Liberty style on both sides of the comparison examples

## Testing
- `npm test` *(fails: The "file" argument must be of type string. Received null)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d7c1acfc832a9ff2b734d4f50e50